### PR TITLE
[4pt] Fetch missions - Fetch data #18

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import logger from 'redux-logger';
 import rocketReducer from '../features/rockets/rockets.slice';
+import missionReducer from '../features/missions/missions.slice';
 
 const store = configureStore({
   reducer: {
     rockets: rocketReducer,
+    missions: missionReducer,
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger),
   devTools: process.env.NODE_ENV !== 'production',

--- a/src/features/missions/missions.slice.jsx
+++ b/src/features/missions/missions.slice.jsx
@@ -1,0 +1,18 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const MISSIONS_URL = 'https://api.spacexdata.com/v3/missions';
+
+export const fetchMissions = createAsyncThunk(
+  'missions/FETCH_MISSIONS',
+  async () => {
+    const response = await axios.get(MISSIONS_URL);
+    const missions = response.data;
+    const modifiedMissions = missions.map((mission) => ({
+      mission_id: mission.mission_id,
+      mission_name: mission.mission_name,
+      description: mission.description,
+    }));
+    return modifiedMissions;
+  },
+);

--- a/src/features/missions/missions.slice.jsx
+++ b/src/features/missions/missions.slice.jsx
@@ -1,18 +1,50 @@
-import { createAsyncThunk } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import axios from 'axios';
 
 const MISSIONS_URL = 'https://api.spacexdata.com/v3/missions';
+// Actions
+const FETCH_MISSIONS = 'missions/FETCH_MISSIONS';
 
-export const fetchMissions = createAsyncThunk(
-  'missions/FETCH_MISSIONS',
-  async () => {
-    const response = await axios.get(MISSIONS_URL);
-    const missions = response.data;
-    const modifiedMissions = missions.map((mission) => ({
-      mission_id: mission.mission_id,
-      mission_name: mission.mission_name,
-      description: mission.description,
-    }));
-    return modifiedMissions;
-  },
+// Action creators
+export const fetchMissions = createAsyncThunk(FETCH_MISSIONS, async () => {
+  const response = await axios.get(MISSIONS_URL);
+  const missions = response.data;
+  const modifiedMissions = missions.map((mission) => ({
+    mission_id: mission.mission_id,
+    mission_name: mission.mission_name,
+    description: mission.description,
+  }));
+  return modifiedMissions;
+},
 );
+
+// Reducer
+const missionsSlice = createSlice({
+  name: 'missions',
+  initialState: {
+    missions: [],
+    loading: false,
+    error: null,
+  },
+  extraReducers: {
+    [fetchMissions.pending]: (state) => {
+      const newState = { ...state, loading: true };
+    },
+    [fetchMissions.fulfilled]: (state, action) => {
+      const newState = {
+        ...state,
+        loading: false,
+        missions: action.payload,
+      };
+    },
+    [fetchMissions.rejected]: (state) => {
+      const newState = {
+        ...state,
+        loading: false,
+        error: action.error.message,
+      };
+    },
+  },
+});
+
+export default missionsSlice.reducer;

--- a/src/features/missions/missions.slice.jsx
+++ b/src/features/missions/missions.slice.jsx
@@ -15,8 +15,7 @@ export const fetchMissions = createAsyncThunk(FETCH_MISSIONS, async () => {
     description: mission.description,
   }));
   return modifiedMissions;
-},
-);
+});
 
 // Reducer
 const missionsSlice = createSlice({
@@ -37,7 +36,7 @@ const missionsSlice = createSlice({
         missions: action.payload,
       };
     },
-    [fetchMissions.rejected]: (state) => {
+    [fetchMissions.rejected]: (state, action) => {
       const newState = {
         ...state,
         loading: false,

--- a/src/features/missions/missions.slice.jsx
+++ b/src/features/missions/missions.slice.jsx
@@ -22,26 +22,29 @@ const missionsSlice = createSlice({
   name: 'missions',
   initialState: {
     missions: [],
-    loading: false,
+    loading: 'idle',
     error: null,
   },
   extraReducers: {
     [fetchMissions.pending]: (state) => {
-      const newState = { ...state, loading: true };
+      const newState = { ...state, loading: 'loading' };
+      return newState;
     },
     [fetchMissions.fulfilled]: (state, action) => {
       const newState = {
         ...state,
-        loading: false,
+        loading: 'succeeded',
         missions: action.payload,
       };
+      return newState;
     },
     [fetchMissions.rejected]: (state, action) => {
       const newState = {
         ...state,
-        loading: false,
+        loading: 'failed',
         error: action.error.message,
       };
+      return newState;
     },
   },
 });

--- a/src/pages/Missions.jsx
+++ b/src/pages/Missions.jsx
@@ -1,5 +1,26 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchMissions } from '../features/missions/missions.slice';
 
-const Missions = () => <div>Missions</div>;
+const Missions = () => {
+  const dispatch = useDispatch();
+  const missionLoading = useSelector((state) => state.missions.loading);
+  const error = useSelector((state) => state.missions.error);
+  useEffect(() => {
+    if (missionLoading === 'idle') {
+      dispatch(fetchMissions());
+    }
+  }, []);
+
+  let tobeDisplay = '';
+  if (missionLoading === 'loading') {
+    tobeDisplay = <div>Loading</div>;
+  } else if (missionLoading === 'succeeded') {
+    tobeDisplay = <div>Successes</div>;
+  } else if (missionLoading === 'failed') {
+    tobeDisplay = <em>{error}</em>;
+  }
+  return tobeDisplay;
+};
 
 export default Missions;


### PR DESCRIPTION
In this pull request, I was able to:
- Fetch data from the Missions [endpoint] (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.
- Once the data are fetched, dispatch an action **once** to store the selected data (mission_id, mission_name, description) in the Redux store.