### PR TITLE
Add reserve cancellation functionality in reserveRocket action.

### DIFF
--- a/src/features/rockets/rockets.slice.js
+++ b/src/features/rockets/rockets.slice.js
@@ -32,6 +32,30 @@ const rocketsSlice = createSlice({
     reserveRocket: (state, action) => {
       const rockets = state.rockets.map((rocket) => {
         if (rocket.id !== action.payload) return rocket;
+        if (rocket.reserved) {
+          return {
+            id: rocket.id,
+            name: rocket.name,
+            type: rocket.name,
+            description: rocket.description,
+            flickr_image: rocket.flickr_image,
+          };
+        }
+        return { ...rocket, reserved: true };
+      });
+      return { ...state, rockets };
+    },
+    cancelReservation: (state, action) => {
+      const rockets = state.rockets.map((rocket) => {
+        if (rocket.id === action.payload) {
+          return {
+            id: rocket.id,
+            name: rocket.name,
+            type: rocket.name,
+            description: rocket.description,
+            flickr_image: rocket.flickr_image,
+          };
+        }
         return { ...rocket, reserved: true };
       });
       return { ...state, rockets };


### PR DESCRIPTION
## Implement rocket booking cancelation - Actions](https://github.com/dgcuenca/spaces-travelers--hub/issues/8)
![image](https://user-images.githubusercontent.com/55840999/216070149-6765250a-d4c4-4d1e-abdc-782c6bcf3db3.png)
### Project Requirement:

- [x] Follow the same logic as with the "Reserve rocket", set the `reserved `key to false.
- [x] Dispatch these actions upon click on the corresponding buttons.

### General Requirements:

- [x]  There are [no linter errors](https://github.com/microverseinc/linters-config).
- [x]  Used correct [Gitflow](https://github.com/microverseinc/curriculum-transversal-skills/blob/main/git-github/articles/gitflow.md).
- [x]  Documented your work [in a professional way](https://github.com/microverseinc/curriculum-transversal-skills/blob/main/documentation/articles/professional_repo_rules.md).
- [x]  Follow the list of [best practices for HTML & CSS](https://github.com/microverseinc/curriculum-html-css/blob/main/articles/html_css_best_practices.md).
- [x]  Follow the list of [best practices for JavaScript](https://github.com/microverseinc/curriculum-html-css/blob/main/articles/javascript_best_practices.md).