### PR TITLE
Feature/switch rocket badges

### DIFF
--- a/src/components/rockets/Rocket.jsx
+++ b/src/components/rockets/Rocket.jsx
@@ -21,7 +21,14 @@ const Rocket = ({ rocket }) => {
       </div>
       <div className={styles.rocket__right}>
         <h2 className={styles.rocket__title}>{rocket.name}</h2>
-        <p className={styles.rocket__description}>{rocket.description}</p>
+        <p className={styles.rocket__description}>
+          {rocket.reserved ? (
+            <span className={styles.rocket__span}>Reserved</span>
+          ) : (
+            ''
+          )}
+          {rocket.description}
+        </p>
         <button
           type="button"
           className={

--- a/src/components/rockets/Rocket.module.scss
+++ b/src/components/rockets/Rocket.module.scss
@@ -28,7 +28,15 @@
   &__description {
     font-size: 0.875rem;
     letter-spacing: 2%;
-    line-height: 1.25rem;
+    line-height: 1.5rem;
+  }
+
+  &__span {
+    background-color: #25a2b7;
+    color: #fff;
+    padding: 4px 5px;
+    border-radius: 5px;
+    margin-right: 4px;
   }
 
   &__button {


### PR DESCRIPTION
## [Switch badges for Rockets - Conditional components #5](https://github.com/dgcuenca/spaces-travelers--hub/issues/5)
![image](https://user-images.githubusercontent.com/55840999/216082164-37757176-2bd3-48c8-b276-be283b167cd2.png)

### Project Requirement:
- [x] Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design).

### General Requirements:
- [x]  There are [no linter errors](https://github.com/microverseinc/linters-config).
- [x]  Used correct [Gitflow](https://github.com/microverseinc/curriculum-transversal-skills/blob/main/git-github/articles/gitflow.md).
- [x]  Documented your work [in a professional way](https://github.com/microverseinc/curriculum-transversal-skills/blob/main/documentation/articles/professional_repo_rules.md).
- [x]  Follow the list of [best practices for HTML & CSS](https://github.com/microverseinc/curriculum-html-css/blob/main/articles/html_css_best_practices.md).
- [x]  Follow the list of [best practices for JavaScript](https://github.com/microverseinc/curriculum-html-css/blob/main/articles/javascript_best_practices.md).